### PR TITLE
Localization Fix - Harmony registered earlier

### DIFF
--- a/src/MonkeFavoritesMod/MonkeFavoritesMod.cs
+++ b/src/MonkeFavoritesMod/MonkeFavoritesMod.cs
@@ -7,8 +7,8 @@ public static class MonkeFavoritesMod
 {
     public static string ModName = "MonkeFavoritesMod";
     
-    [Hook(ModHookType.AfterBootstrap)]
-    public static void AfterBootstrap(IModContext context)
+    [Hook(ModHookType.BeforeBootstrap)]
+    public static void BeforeBootstrap(IModContext context)
     {
         Debug.Log("Mod Launched");
         new Harmony(ModName).PatchAll(Assembly.GetExecutingAssembly());


### PR DESCRIPTION
Localization Fix - Harmony registered earlier

Changed Harmony patch registration to be executed
before any Localization code is executed.  Fixes
Localization strings not being registered.